### PR TITLE
Changes to module dir location

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -27,6 +27,20 @@ function usage() {
           'phantomjs lib/run.js [url] [WCAG2A|WCAG2AA|WCAG2AAA]');
 }
 
+function setModuleDirPath(path) {
+   var CS = '/node_modules/HTML_CodeSniffer/';
+
+   var isCSExist = fs.isDirectory(path + CS);
+   if (isCSExist) {
+        return path + CS;
+   }
+   //might be installed from boilerplate lets change path
+   var rootDir = require('system').args[0].split(/\//g);
+       rootDir = rootDir.slice(0, rootDir.length-4).join('/');
+
+   return rootDir + CS;
+}
+
 if (args.length < 2) {
     usage();
     phantom.exit();
@@ -38,7 +52,7 @@ var rootDir = require('system').args[0].split(/\//g);
 rootDir = rootDir.slice(0, rootDir.length-2).join('/');
 var address = args[0];
 var standard = args[1];
-var moduleDir = rootDir + '/node_modules/HTML_CodeSniffer/';
+var moduleDir = setModuleDirPath(rootDir);
 
 page.onError = function(msg, trace) {
     errors.push({


### PR DESCRIPTION
We hit a problem when gulp-htmlcs is pulled from Squiz-Boilerplate; reference to HTML_CodeSniffer are not set correctly (pointing to gulp-htmlcs/node_modueles/HTML_CodeSniffer). Function changes location to main node modules directory if cannot find in local.